### PR TITLE
修复模型调用eval()时生成的表达式里用了import语句导致出错的bug

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -19,8 +19,8 @@ mcp = FastMCP("Calculator")
 # Add an addition tool
 @mcp.tool()
 def calculator(python_expression: str) -> dict:
-    """For mathamatical calculation, always use this tool to calculate the result of a python expression. `math` and `random` are available."""
-    result = eval(python_expression)
+    """For mathamatical calculation, always use this tool to calculate the result of a python expression.You can use 'math' or 'random' directly, without 'import'."""
+    result = eval(python_expression, {"math": math, "random": random})
     logger.info(f"Calculating formula: {python_expression}, result: {result}")
     return {"success": True, "result": result}
 


### PR DESCRIPTION
修改前，在计算圆周长面积也就是调用math的时候，出错了，模型在生成表达式的时候，在eval的参数中导入了math.
![image](https://github.com/user-attachments/assets/252d90f2-3b61-467e-854b-da54cbe10650)
修改后，可以直接使用math或者random模块。
![image](https://github.com/user-attachments/assets/6127423b-ee5c-441f-a365-117342a4d420)
![image](https://github.com/user-attachments/assets/56a5a474-cb27-4178-8c89-b754883bc03d)
这里测试的时候没有用同样的计算圆的指令，因为小智绕过了math的pi，直接用的数值。
![image](https://github.com/user-attachments/assets/828be2e4-e4e8-48ac-bafa-0cb69adc9c07)

