### PR TITLE
fix: venv support

### DIFF
--- a/mcp_pipe.py
+++ b/mcp_pipe.py
@@ -68,7 +68,7 @@ async def connect_to_server(uri):
             
             # Start mcp_script process
             process = subprocess.Popen(
-                ['python', mcp_script],
+                [sys.executable, mcp_script],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
调整适配 venv 虚拟环境下 subprocess 启动 python 不一致的问题
> 当前 subprocess 启动的是系统安装的 python , 而非 venv 下的 python 解释器
> 若 全局 python 没有安装过 requirements.txt 的相关依赖, 运行服务是会报错找不到相关依赖模块的