### PR TITLE
feat: Add remote SSE/HTTP transport support to reuse existing MCP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .venv/
 __pycache__/
 node_modules/
+
+.env

--- a/README.md
+++ b/README.md
@@ -28,22 +28,21 @@ pip install -r requirements.txt
 
 2) Set endpoint | 设置环境变量
 
-Fish:
-
-```fish
-set -x MCP_ENDPOINT <your_ws_endpoint>
-```
-
-Bash/zsh:
-
 ```bash
 export MCP_ENDPOINT=<your_ws_endpoint>
+# Windows (PowerShell): $env:MCP_ENDPOINT="<your_ws_endpoint>"
 ```
 
-3) Run (all servers) | 运行（全部服务）
+3) Run (from config) | 运行（基于配置）
 
 ```bash
 python mcp_pipe.py
+```
+
+Run a single local server script | 运行单个本地脚本服务
+
+```bash
+python mcp_pipe.py calculator.py
 ```
 
 ## Project Structure | 项目结构
@@ -55,7 +54,7 @@ python mcp_pipe.py
 ## Config-driven Servers | 通过配置驱动的服务
 
 - 修改 `mcp_config.json`（或设置 `MCP_CONFIG` 指向该文件）来定义 `mcpServers` 列表。
-- 运行时默认同时启动所有配置的服务；仅支持 “all” 模式。
+- 无参数时启动所有配置的服务；如需单个运行，请传入本地脚本路径。
 - 说明：type=stdio 直接启动；type=sse/http 通过 `python -m mcp_proxy` 代理到 stdio。
 
 ## Creating Your Own MCP Tools | 创建自己的MCP工具
@@ -90,7 +89,6 @@ if __name__ == "__main__":
 
 - Python 3.7+
 - websockets>=11.0.3
-- python-dotenv>=1.0.0
 - mcp>=1.8.1
 - pydantic>=2.11.4
 - mcp-proxy>=0.8.2

--- a/README.md
+++ b/README.md
@@ -20,19 +20,30 @@ MCP（模型上下文协议）是一个允许服务器向语言模型暴露可�
 
 ## Quick Start | 快速开始
 
-1. Install dependencies | 安装依赖:
+1) Install deps | 安装依赖
+
 ```bash
 pip install -r requirements.txt
 ```
 
-2. Set up environment variables | 设置环境变量:
-```bash
-export MCP_ENDPOINT=<your_mcp_endpoint>
+2) Set endpoint | 设置环境变量
+
+Fish:
+
+```fish
+set -x MCP_ENDPOINT <your_ws_endpoint>
 ```
 
-3. Run the calculator example | 运行计算器示例:
+Bash/zsh:
+
 ```bash
-python mcp_pipe.py calculator.py
+export MCP_ENDPOINT=<your_ws_endpoint>
+```
+
+3) Run (all servers) | 运行（全部服务）
+
+```bash
+python mcp_pipe.py
 ```
 
 ## Project Structure | 项目结构
@@ -40,6 +51,12 @@ python mcp_pipe.py calculator.py
 - `mcp_pipe.py`: Main communication pipe that handles WebSocket connections and process management | 处理WebSocket连接和进程管理的主通信管道
 - `calculator.py`: Example MCP tool implementation for mathematical calculations | 用于数学计算的MCP工具示例实现
 - `requirements.txt`: Project dependencies | 项目依赖
+
+## Config-driven Servers | 通过配置驱动的服务
+
+- 修改 `mcp_config.json`（或设置 `MCP_CONFIG` 指向该文件）来定义 `mcpServers` 列表。
+- 运行时默认同时启动所有配置的服务；仅支持 “all” 模式。
+- 说明：type=stdio 直接启动；type=sse/http 通过 `python -m mcp_proxy` 代理到 stdio。
 
 ## Creating Your Own MCP Tools | 创建自己的MCP工具
 
@@ -76,6 +93,7 @@ if __name__ == "__main__":
 - python-dotenv>=1.0.0
 - mcp>=1.8.1
 - pydantic>=2.11.4
+- mcp-proxy>=0.8.2
 
 ## Contributing | 贡献指南
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A powerful interface for extending AI capabilities through remote control, calcu
 
 ## Overview | 概述
 
-MCP (Model Context Protocol) is a protocol that allows servers to expose tools that can be invoked by language models. Tools enable models to interact with external systems, such as querying databases, calling APIs, or executing tasks.
+MCP (Model Context Protocol) is a protocol that allows servers to expose tools that can be invoked by language models. Tools enable models to interact with external systems, such as querying databases, calling APIs, or performing computations. Each tool is uniquely identified by a name and includes metadata describing its schema.
 
-MCP（模型上下文协议）是一个允许服务器向语言模型暴露可调用工具的协议。这些工具使模型能够与外部系统交互，例如查询数据库、调用API或执行任务。
+MCP（模型上下文协议）是一个允许服务器向语言模型暴露可调用工具的协议。这些工具使模型能够与外部系统交互，例如查询数据库、调用API或执行计算。每个工具都由一个唯一的名称标识，并包含描述其模式的元数据。
 
 ## Features | 特性
 
@@ -17,33 +17,33 @@ MCP（模型上下文协议）是一个允许服务器向语言模型暴露可�
 - 📊 Real-time data streaming | 实时数据流传输
 - 🛠️ Easy-to-use tool creation interface | 简单易用的工具创建接口
 - 🔒 Secure WebSocket communication | 安全的WebSocket通信
+- ⚙️ Multiple transport types support (stdio/sse/http) | 支持多种传输类型（stdio/sse/http）
 
 ## Quick Start | 快速开始
 
-1) Install deps | 安装依赖
-
+1. Install dependencies | 安装依赖:
 ```bash
 pip install -r requirements.txt
 ```
 
-2) Set endpoint | 设置环境变量
-
+2. Set up environment variables | 设置环境变量:
 ```bash
-export MCP_ENDPOINT=<your_ws_endpoint>
-# Windows (PowerShell): $env:MCP_ENDPOINT="<your_ws_endpoint>"
+export MCP_ENDPOINT=<your_mcp_endpoint>
 ```
 
-3) Run | 运行
+3. Run the calculator example | 运行计算器示例:
+```bash
+python mcp_pipe.py calculator.py
+```
 
+Or run all configured servers | 或运行所有配置的服务:
 ```bash
 python mcp_pipe.py
 ```
 
-Run a single local server script | 运行单个本地脚本服务
+*Requires `mcp_config.json` configuration file with server definitions (supports stdio/sse/http transport types)*
 
-```bash
-python mcp_pipe.py calculator.py
-```
+*需要 `mcp_config.json` 配置文件定义服务器（支持 stdio/sse/http 传输类型）*
 
 ## Project Structure | 项目结构
 
@@ -53,9 +53,12 @@ python mcp_pipe.py calculator.py
 
 ## Config-driven Servers | 通过配置驱动的服务
 
-- 修改 `mcp_config.json`（或设置 `MCP_CONFIG` 指向该文件）来定义 `mcpServers` 列表。
-- 无参数时启动所有配置的服务（自动跳过配置里 disabled: true 的条目）；如需单个运行，请传入本地脚本路径。
-- 说明：type=stdio 直接启动；type=sse/http 通过 `python -m mcp_proxy` 代理到 stdio。
+编辑 `mcp_config.json` 文件来配置服务器列表（也可设置 `MCP_CONFIG` 环境变量指向其他配置文件）。
+
+配置说明：
+- 无参数时启动所有配置的服务（自动跳过 `disabled: true` 的条目）
+- 有参数时运行单个本地脚本文件
+- `type=stdio` 直接启动；`type=sse/http` 通过 `python -m mcp_proxy` 代理
 
 ## Creating Your Own MCP Tools | 创建自己的MCP工具
 
@@ -89,6 +92,7 @@ if __name__ == "__main__":
 
 - Python 3.7+
 - websockets>=11.0.3
+- python-dotenv>=1.0.0
 - mcp>=1.8.1
 - pydantic>=2.11.4
 - mcp-proxy>=0.8.2
@@ -97,7 +101,7 @@ if __name__ == "__main__":
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
-欢迎贡献代码！请随时提交PullRequest。
+欢迎贡献代码！请随时提交Pull Request。
 
 ## License | 许可证
 

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "calculator": {
+      "timeout": 60,
+      "type": "stdio",
+      "command": "python",
+      "args": ["-m", "calculator"]
+    },
+    "desktop-commander": {
+      "command": "npx",
+      "args": ["-y", "@wonderwhy-er/desktop-commander"]
+    }
+  }
+}

--- a/mcp_pipe.py
+++ b/mcp_pipe.py
@@ -1,6 +1,6 @@
 """
 Simple MCP stdio <-> WebSocket pipe with optional unified config.
-Version: 0.3.0
+Version: 0.2.0
 
 Usage (env):
     export MCP_ENDPOINT=<ws_endpoint>

--- a/mcp_pipe.py
+++ b/mcp_pipe.py
@@ -1,12 +1,19 @@
 """
-This script is used to connect to the MCP server and pipe the input and output to the websocket endpoint.
-Version: 0.1.0
+Simple MCP stdio <-> WebSocket pipe with optional unified config.
+Version: 0.3.0
 
-Usage:
+Usage (env):
+    export MCP_ENDPOINT=<ws_endpoint>
 
-export MCP_ENDPOINT=<mcp_endpoint>
-python mcp_pipe.py <mcp_script>
+Start server process(es):
+All configured servers: start one pipe per server concurrently
+    python mcp_pipe.py
 
+Config discovery order:
+    $MCP_CONFIG, then ./mcp_config.json
+
+Env overrides:
+    (none for proxy; uses current Python: python -m mcp_proxy)
 """
 
 import asyncio
@@ -17,9 +24,11 @@ import os
 import signal
 import sys
 import random
+import json
+# (No .env auto-loading; rely on environment being set by caller)
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
+# Load environment variables from .env file (restores original behavior)
 load_dotenv()
 
 # Configure logging
@@ -32,81 +41,77 @@ logger = logging.getLogger('MCP_PIPE')
 # Reconnection settings
 INITIAL_BACKOFF = 1  # Initial wait time in seconds
 MAX_BACKOFF = 600  # Maximum wait time in seconds
-reconnect_attempt = 0
-backoff = INITIAL_BACKOFF
 
-async def connect_with_retry(uri):
-    """Connect to WebSocket server with retry mechanism"""
-    global reconnect_attempt, backoff
+async def connect_with_retry(uri, target):
+    """Connect to WebSocket server with retry mechanism for a given server target."""
+    reconnect_attempt = 0
+    backoff = INITIAL_BACKOFF
     while True:  # Infinite reconnection
         try:
             if reconnect_attempt > 0:
                 wait_time = backoff * (1 + random.random() * 0.1)  # Add some random jitter
-                logger.info(f"Waiting {wait_time:.2f} seconds before reconnection attempt {reconnect_attempt}...")
+                logger.info(f"[{target}] Waiting {wait_time:.2f}s before reconnection attempt {reconnect_attempt}...")
                 await asyncio.sleep(wait_time)
-                
+
             # Attempt to connect
-            await connect_to_server(uri)
-        
+            await connect_to_server(uri, target)
+
         except Exception as e:
             reconnect_attempt += 1
-            logger.warning(f"Connection closed (attempt: {reconnect_attempt}): {e}")            
+            logger.warning(f"[{target}] Connection closed (attempt {reconnect_attempt}): {e}")
             # Calculate wait time for next reconnection (exponential backoff)
             backoff = min(backoff * 2, MAX_BACKOFF)
 
-async def connect_to_server(uri):
-    """Connect to WebSocket server and establish bidirectional communication with `mcp_script`"""
-    global reconnect_attempt, backoff
+async def connect_to_server(uri, target):
+    """Connect to WebSocket server and pipe stdio for the given server target."""
     try:
-        logger.info(f"Connecting to WebSocket server...")
+        logger.info(f"[{target}] Connecting to WebSocket server...")
         async with websockets.connect(uri) as websocket:
-            logger.info(f"Successfully connected to WebSocket server")
-            
-            # Reset reconnection counter if connection closes normally
-            reconnect_attempt = 0
-            backoff = INITIAL_BACKOFF
-            
-            # Start mcp_script process
+            logger.info(f"[{target}] Successfully connected to WebSocket server")
+
+            # Start server process (built from CLI arg or config)
+            cmd, env = build_server_command(target)
             process = subprocess.Popen(
-                [sys.executable, mcp_script],
+                cmd,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 encoding='utf-8',
-                text=True  # Use text mode
+                text=True,
+                env=env
             )
-            logger.info(f"Started {mcp_script} process")
+            logger.info(f"[{target}] Started server process: {' '.join(cmd)}")
             
             # Create two tasks: read from WebSocket and write to process, read from process and write to WebSocket
             await asyncio.gather(
-                pipe_websocket_to_process(websocket, process),
-                pipe_process_to_websocket(process, websocket),
-                pipe_process_stderr_to_terminal(process)
+                pipe_websocket_to_process(websocket, process, target),
+                pipe_process_to_websocket(process, websocket, target),
+                pipe_process_stderr_to_terminal(process, target)
             )
     except websockets.exceptions.ConnectionClosed as e:
-        logger.error(f"WebSocket connection closed: {e}")
+        logger.error(f"[{target}] WebSocket connection closed: {e}")
         raise  # Re-throw exception to trigger reconnection
     except Exception as e:
-        logger.error(f"Connection error: {e}")
+        logger.error(f"[{target}] Connection error: {e}")
         raise  # Re-throw exception
     finally:
         # Ensure the child process is properly terminated
         if 'process' in locals():
-            logger.info(f"Terminating {mcp_script} process")
+            logger.info(f"[{target}] Terminating server process")
             try:
                 process.terminate()
                 process.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 process.kill()
-            logger.info(f"{mcp_script} process terminated")
+            logger.info(f"[{target}] Server process terminated")
 
-async def pipe_websocket_to_process(websocket, process):
+async def pipe_websocket_to_process(websocket, process, target):
     """Read data from WebSocket and write to process stdin"""
     try:
         while True:
             # Read message from WebSocket
             message = await websocket.recv()
-            logger.debug(f"<< {message[:120]}...")
+            logger.debug(f"[{target}] << {message[:120]}...")
             
             # Write to process stdin (in text mode)
             if isinstance(message, bytes):
@@ -114,14 +119,14 @@ async def pipe_websocket_to_process(websocket, process):
             process.stdin.write(message + '\n')
             process.stdin.flush()
     except Exception as e:
-        logger.error(f"Error in WebSocket to process pipe: {e}")
+        logger.error(f"[{target}] Error in WebSocket to process pipe: {e}")
         raise  # Re-throw exception to trigger reconnection
     finally:
         # Close process stdin
         if not process.stdin.closed:
             process.stdin.close()
 
-async def pipe_process_to_websocket(process, websocket):
+async def pipe_process_to_websocket(process, websocket, target):
     """Read data from process stdout and send to WebSocket"""
     try:
         while True:
@@ -131,18 +136,18 @@ async def pipe_process_to_websocket(process, websocket):
             )
             
             if not data:  # If no data, the process may have ended
-                logger.info("Process has ended output")
+                logger.info(f"[{target}] Process has ended output")
                 break
                 
             # Send data to WebSocket
-            logger.debug(f">> {data[:120]}...")
+            logger.debug(f"[{target}] >> {data[:120]}...")
             # In text mode, data is already a string, no need to decode
             await websocket.send(data)
     except Exception as e:
-        logger.error(f"Error in process to WebSocket pipe: {e}")
+        logger.error(f"[{target}] Error in process to WebSocket pipe: {e}")
         raise  # Re-throw exception to trigger reconnection
 
-async def pipe_process_stderr_to_terminal(process):
+async def pipe_process_stderr_to_terminal(process, target):
     """Read data from process stderr and print to terminal"""
     try:
         while True:
@@ -152,14 +157,14 @@ async def pipe_process_stderr_to_terminal(process):
             )
             
             if not data:  # If no data, the process may have ended
-                logger.info("Process has ended stderr output")
+                logger.info(f"[{target}] Process has ended stderr output")
                 break
                 
             # Print stderr data to terminal (in text mode, data is already a string)
             sys.stderr.write(data)
             sys.stderr.flush()
     except Exception as e:
-        logger.error(f"Error in process stderr pipe: {e}")
+        logger.error(f"[{target}] Error in process stderr pipe: {e}")
         raise  # Re-throw exception to trigger reconnection
 
 def signal_handler(sig, frame):
@@ -167,16 +172,80 @@ def signal_handler(sig, frame):
     logger.info("Received interrupt signal, shutting down...")
     sys.exit(0)
 
+
+# ---------- Simple config + command builder ----------
+
+def load_config():
+    """Load JSON config from $MCP_CONFIG or ./mcp_config.json. Return dict or {}."""
+    path = os.environ.get("MCP_CONFIG") or os.path.join(os.getcwd(), "mcp_config.json")
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        logger.warning(f"Failed to load config {path}: {e}")
+        return {}
+
+
+def build_server_command(target=None):
+    """Build [cmd,...] and env for the server process for a given target.
+
+    Priority:
+    - target must match a server in config.mcpServers
+    If target is None, read from sys.argv[1].
+    """
+    if target is None:
+        assert len(sys.argv) >= 2, "missing server name or script path"
+        target = sys.argv[1]
+    cfg = load_config()
+    servers = cfg.get("mcpServers", {}) if isinstance(cfg, dict) else {}
+
+    if target in servers:
+        entry = servers[target] or {}
+        if entry.get("disabled"):
+            raise RuntimeError(f"Server '{target}' is disabled in config")
+        typ = (entry.get("type") or entry.get("transportType") or "stdio").lower()
+
+        # environment for child process
+        child_env = os.environ.copy()
+        for k, v in (entry.get("env") or {}).items():
+            child_env[str(k)] = str(v)
+
+        if typ == "stdio":
+            command = entry.get("command")
+            args = entry.get("args") or []
+            if not command:
+                raise RuntimeError(f"Server '{target}' is missing 'command'")
+            return [command, *args], child_env
+
+        if typ in ("sse", "http", "streamablehttp"):
+            url = entry.get("url")
+            if not url:
+                raise RuntimeError(f"Server '{target}' (type {typ}) is missing 'url'")
+            # Unified approach: always use current Python to run mcp-proxy module
+            cmd = [sys.executable, "-m", "mcp_proxy"]
+            if typ in ("http", "streamablehttp"):
+                cmd += ["--transport", "streamablehttp"]
+            # optional headers: {"Authorization": "Bearer xxx"}
+            headers = entry.get("headers") or {}
+            for hk, hv in headers.items():
+                cmd += ["-H", hk, str(hv)]
+            cmd.append(url)
+            return cmd, child_env
+
+        raise RuntimeError(f"Unsupported server type: {typ}")
+
+    # No fallback: only configured servers are supported
+    raise RuntimeError(
+        f"'{target}' is not a configured server in mcp_config.json"
+    )
+
 if __name__ == "__main__":
     # Register signal handler
     signal.signal(signal.SIGINT, signal_handler)
     
-    # mcp_script
-    if len(sys.argv) < 2:
-        logger.error("Usage: mcp_pipe.py <mcp_script>")
-        sys.exit(1)
-    
-    mcp_script = sys.argv[1]
+    # No arguments supported; always runs all configured servers
     
     # Get token from environment variable or command line arguments
     endpoint_url = os.environ.get('MCP_ENDPOINT')
@@ -184,9 +253,23 @@ if __name__ == "__main__":
         logger.error("Please set the `MCP_ENDPOINT` environment variable")
         sys.exit(1)
     
-    # Start main loop
+    # Reject any arguments; no CLI args are supported
+    if len(sys.argv) >= 2:
+        logger.error("This script takes no arguments. Run: python mcp_pipe.py")
+        sys.exit(1)
+
+    async def _main():
+        cfg = load_config()
+        servers = list((cfg.get("mcpServers") or {}).keys())
+        if not servers:
+            raise RuntimeError("No mcpServers found in config")
+        logger.info(f"Starting all servers: {', '.join(servers)}")
+        tasks = [asyncio.create_task(connect_with_retry(endpoint_url, t)) for t in servers]
+        # Run all forever; if any crashes it will auto-retry inside
+        await asyncio.gather(*tasks)
+
     try:
-        asyncio.run(connect_with_retry(endpoint_url))
+        asyncio.run(_main())
     except KeyboardInterrupt:
         logger.info("Program interrupted by user")
     except Exception as e:

--- a/mcp_pipe.py
+++ b/mcp_pipe.py
@@ -249,7 +249,7 @@ if __name__ == "__main__":
         logger.error("Please set the `MCP_ENDPOINT` environment variable")
         sys.exit(1)
     
-    # Determine target: default to all if no arg; support single target or explicit 'all'
+    # Determine target: default to all if no arg; single target otherwise
     target_arg = sys.argv[1] if len(sys.argv) >= 2 else None
 
     async def _main():
@@ -268,9 +268,6 @@ if __name__ == "__main__":
             # Run all forever; if any crashes it will auto-retry inside
             await asyncio.gather(*tasks)
         else:
-            if target_arg.lower() == "all":
-                logger.error("Pass no arguments to start all configured servers. To run a single server, provide a local Python script path.")
-                sys.exit(1)
             if os.path.exists(target_arg):
                 await connect_with_retry(endpoint_url, target_arg)
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv>=1.0.0
 websockets>=11.0.3 
 mcp>=1.8.1
 pydantic>=2.11.4
+mcp-proxy>=0.8.2


### PR DESCRIPTION
## What Changed
Added support for remote MCP servers via SSE/HTTP transports, allowing reuse of existing deployed MCP servers through JSON configuration.

## Key Features
- **Remote server support**: Connect to existing MCP servers via SSE/HTTP
- **Local server support**: Run local stdio servers (backward compatible)
- **Unified config**: Manage all servers in `mcp_config.json`
- **Transport flexibility**: stdio, sse, http via mcp-proxy integration

## Example Config
```json
{
  "mcpServers": {
    "calculator": {
      "type": "stdio",
      "command": "python", 
      "args": ["-m", "calculator"]
    },
    "remote-api": {
      "type": "sse",
      "url": "https://api.example.com/mcp"
    },
    "http-service": {
      "type": "http",
      "url": "https://api.example.com/mcp-http",
      "headers": {
        "Authorization": "Bearer token"
      }
    }
  }
}
```

## Benefits
- Reuse existing servers: No need to redeploy or modify remote MCP servers
- Mixed deployments: Combine local and remote servers seamlessly
- Easy scaling: Add/remove servers via config without code changes