### PR TITLE
fix: 1. Use latest FastMCP import method 2. Add missing fastmcp dependency

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -1,5 +1,5 @@
 # server.py
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 import sys
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-python-dotenv>=1.0.0
-websockets>=11.0.3 
-mcp>=1.8.1
-pydantic>=2.11.4
-mcp-proxy>=0.8.2
+python-dotenv>=1.2.1
+websockets>=15.0.1
+mcp>=1.20.0
+pydantic>=2.12.3
+mcp-proxy>=0.10.0
+fastmcp>=2.13.0.2


### PR DESCRIPTION
(venv) lv@SUPER-AMD:~/laoshanxi/mcp-calculator$ python3 mcp_pipe.py
2025-11-06 07:33:16,818 - MCP_PIPE - INFO - Skipping disabled servers: remote-sse-server, remote-http-server
2025-11-06 07:33:16,818 - MCP_PIPE - INFO - Starting servers: local-stdio-calculator
2025-11-06 07:33:16,818 - MCP_PIPE - INFO - [local-stdio-calculator] Connecting to WebSocket server...
2025-11-06 07:33:17,124 - MCP_PIPE - INFO - [local-stdio-calculator] Successfully connected to WebSocket server
2025-11-06 07:33:17,128 - MCP_PIPE - INFO - [local-stdio-calculator] Started server process: python -m calculator


╭──────────────────────────────────────────────────────────────────────────────╮
│                                                                              │
│                         ▄▀▀ ▄▀█ █▀▀ ▀█▀ █▀▄▀█ █▀▀ █▀█                        │
│                         █▀  █▀█ ▄▄█  █  █ ▀ █ █▄▄ █▀▀                        │
│                                                                              │
│                               FastMCP 2.13.0.2                               │
│                                                                              │
│                                                                              │
│                    🖥  Server name: Calculator                                │
│                                                                              │
│                    📦 Transport:   STDIO                                     │
│                                                                              │
│                    📚 Docs:        https://gofastmcp.com                     │
│                    🚀 Hosting:     https://fastmcp.cloud                     │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


[11/06/25 07:33:26] INFO     Starting MCP server 'Calculator'     server.py:1966
                             with transport 'stdio'